### PR TITLE
EIUNAB-3645/Impact : Work with Teams to get the YAML into Backstage.io for all projects

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -5,6 +5,14 @@ metadata:
   namespace: economist-impact
   annotations:
     github.com/project-slug: signal-noise/multi-window-video
+      # the circleCI project, mirrors github repo in this case: 
+    circleci.com/project-slug: github/signal-noise/multi-window-video
+      # GUID - see https://docs.newrelic.com/docs/query-your-data/explore-query-data/dashboards/manage-your-dashboard/
+    newrelic.com/dashboard-guid: MzY1MjgxOXxWSVp8REFTSEJPQVJEfGRhOjE3MDkwOA
+    newrelic.com/dashboard-guid: MzY1MjgxOXxWSVp8REFTSEJPQVJEfGRhOjE5NTIyNw
+    description: covid-relative-risk for SignalNoise Economist Impact Project
+    opsgenie:
+      domain: https://economist.app.opsgenie.com/teams/dashboard/49177ca8-5e59-4364-af23-c22cc60c026f/main
     backstage.io/techdocs-ref: dir:.
 spec:
   type: website

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1beta1
+kind: Component
+metadata:
+  name: multi-window-video
+  namespace: economist-impact
+  annotations:
+    github.com/project-slug: signal-noise/multi-window-video
+    backstage.io/techdocs-ref: dir:.
+spec:
+  type: website
+  lifecycle: production
+  owner: group:economist-impact/signal-noise

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,64 @@
+# multi-window-video
+
+[![Actions Status][ci-image]][ci-url]
+
+A tool to allow videos to be triggered and synchronized across multiple browser windows. The user can press a key on the keyboard to trigger various videos.
+
+
+## Contacts and documents
+
+John Chipps-Harding (john@signal-noise.co.uk)
+
+## Architecture
+
+This project runs in multiple browser windows on the same machine. They communicate using the standard `BroadcastChannel` system.
+
+### Specifics
+
+Place videos within the `/videos` folder and configure the system by changing the config object within `/src/index.js`.
+
+Example config:
+```javascript
+const config = {
+  videos: [
+    {
+       // What keyboard key to press to trigger this state
+      key: "1",
+
+       // A list of videos to play on each screen. This example supports 3 screens.
+      src: ["./videos/w1_v1.mp4", "./videos/w2_v1.mp4", "./videos/w3_v1.mp4"]
+    },
+    {
+      key: "2",
+      src: ["./videos/w1_v2.mp4", "./videos/w2_v2.mp4", "./videos/w3_v2.mp4"]
+    }
+  ],
+
+  // If true, all videos are muted, if false all but the first window will be muted.
+  mute: false,
+
+  sync: {
+    // How often to check sync (2 seconds)
+    interval: 2,
+
+    // How much difference there can be before a sync is triggered.
+    threshold: 0.3,
+
+    // How much time at the beginning of the clip to ignore syncing.
+    ignore: 1
+  }
+};
+```
+
+## Getting started
+
+Follow these steps to get up and running:
+
+1. Run `npm i` to install all dependencies.
+2. Run `npm start` to launch the system.
+3. By default starting this will launch three browser windows with the correct querystrings applied. E.g. a URL may be `http://localhost:8080?window=1`.
+
+> Note: Windows are zero indexed, so the first window is **0**.
+
+[ci-image]: https://github.com/signal-noise/multi-window-video/workflows/node-ci/badge.svg
+[ci-url]: https://github.com/signal-noise/multi-window-video/actions

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,5 @@
+docs_dir: docs
+nav:
+  - Main: index.md
+plugins:
+  - techdocs-core


### PR DESCRIPTION
Description
Add to Backstage - Economist Impact Signal Noise Team

Reason for change
Backstage.io rollout across the Economist Group via platform.economist.com

Breaking changes
None

Remarks
Github added, CircleCI Added (where CICD applicable), New Relic added, Opsgenie added (where applicable), docs file added to be updated in depth by the team upon review.

Testing
Once merged the Enablement team will test integration into backstage. The yaml files are pulled via polling on the main branch for automated incorporation.

Checklist
My commits, pull request name follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
style
I have made corresponding changes to the documentation
I have updated unit tests, integration tests
I have tested in dev environment
I have update swagger, where applicable
I have provided cdk diff result for infrastructure changes, where applicable